### PR TITLE
Test add tests for the proof of work aka calculate block target hash and mine block functions

### DIFF
--- a/blockchain/block.test.js
+++ b/blockchain/block.test.js
@@ -3,10 +3,44 @@ const { keccakHash } = require('../util');
 
 describe('Block', () => {
   describe('calculateBlockTargetHash()', () => {
+    it('calculates the maximum hash when the last block difficulty is 1', () => {
+      expect(
+        Block
+          .calculateBlockTargetHash({ lastBlock: { blockHeaders: { difficulty: 1 } } })
+      ).toEqual('f'.repeat(64));
+    });
 
+    it('calculates a low hash value when the last block difficulty is high', () => {
+      expect(
+        Block
+          .calculateBlockTargetHash({ lastBlock: { blockHeaders: { difficulty: 500 } } })
+        < '1'
+      ).toBe(true);
+    });
   });
 
   describe('mineBlock()', () => {
+    let lastBlock, minedBlock;
 
+    beforeEach(() => {
+      lastBlock = Block.genesis();
+      minedBlock = Block.mineBlock({ lastBlock, beneficiary: 'beneficiary' });
+    });
+
+    it('mines a block', () => {
+      expect(minedBlock).toBeInstanceOf(Block);
+    });
+
+    it('mines a block that meets the proof of work requirement', () => {
+      const target = Block.calculateBlockTargetHash({ lastBlock });
+      const { blockHeaders } = minedBlock;
+      const { nonce } = blockHeaders;
+      const truncatedBlockHeaders = { ...blockHeaders };
+      delete truncatedBlockHeaders.nonce;
+      const header = keccakHash(truncatedBlockHeaders);
+      const underTargetHash = keccakHash(header + nonce);
+
+      expect(underTargetHash < target).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Problem  
Only genesis blocks can be made with the current Block class It lacks the fundamental proof-of-work mining capabilities required for a functional blockchain. It is impossible to create new blocks with the proper cryptographic proof-of-work validation without these functions. Because of this, the blockchain cannot be expanded past the original genesis block.

## Resolution  
By adding two crucial static methods to the Block clas,s this PR adds the primary proof-of-work mining algorithm. Based on the difficulty level of the previous block, the `calculateBlockTargetHash()` method determines the difficulty target. The mining process is carried out by the `mineBlock()` method, which tries various nonce values until it finds a hash that satisfies the goal.

## Detailed Requirements
The implementation must include a `calculateBlockTargetHash()` method taht accepts a lastBlock parameter and returns a hexadecimal target hash string calculated by dividing the maximum hash value by the block difficult,y with proper padding to maintain 64-character length The `mineBlock()` method should accept lastBlock and beneficiary parameters, generate new block headers with incremented difficulty and block numbre, perform proof-of-work mining by testing random nonce values until the resulting hash is below the target, and return a new Block instance. Focus on implementing these core mining faetures for no,w as additional blockchain functionality such as transaction handling, network consensus, and advanced difficulty adjustment algorithms will be added in subsequent iterations.
